### PR TITLE
fix(project): changed rmcneill to rhysmcneill across the project

### DIFF
--- a/cmd/helm-semver/main.go
+++ b/cmd/helm-semver/main.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rmcneill/helm-semver/internal/changelog"
-	"github.com/rmcneill/helm-semver/internal/chart"
-	igit "github.com/rmcneill/helm-semver/internal/git"
-	"github.com/rmcneill/helm-semver/internal/registry"
-	"github.com/rmcneill/helm-semver/internal/release"
-	"github.com/rmcneill/helm-semver/internal/semver"
-	"github.com/rmcneill/helm-semver/internal/version"
+	"github.com/rhysmcneill/helm-semver/internal/changelog"
+	"github.com/rhysmcneill/helm-semver/internal/chart"
+	igit "github.com/rhysmcneill/helm-semver/internal/git"
+	"github.com/rhysmcneill/helm-semver/internal/registry"
+	"github.com/rhysmcneill/helm-semver/internal/release"
+	"github.com/rhysmcneill/helm-semver/internal/semver"
+	"github.com/rhysmcneill/helm-semver/internal/version"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rmcneill/helm-semver
+module github.com/rhysmcneill/helm-semver
 
 go 1.26.2
 


### PR DESCRIPTION
## Summary:

When trying to go through the installation guide, this error is thrown:

```bash
go install github.com/rhysmcneill/helm-semver/cmd
/helm-semver@latest
go: github.com/rhysmcneill/helm-semver/cmd/helm-semver@latest: version constraints conflict:
        github.com/rhysmcneill/helm-semver@v1.0.6: parsing go.mod:
        module declares its path as: github.com/rmcneill/helm-semver
                but was required as: github.com/rhysmcneill/helm-semver
```

This PR looks to fix this issue. All instances of `rmcneill` was changed in-place to `rhysmcneill`. 

Files affected:
- `go.mod`
- `cmd/helm-semver/main.go`