### PR TITLE
feat(workflows): added pr-title.yml in workflows to mirror ssmctl

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,34 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    if: github.repository == 'rhysmcneill/helm-semver'
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            test
+            chore
+            perf
+            style
+            ci
+            release
+            infra
+          requireScope: false
+          subjectPattern: ^[a-z].+$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter.


### PR DESCRIPTION
## Summary

`ssmctl` has a workflow to check PR titles. It make sense to have a similar workflow for `helm-semver`. 

## Changes

- added `.github/workflows/pr-title.yml`