### PR TITLE
fix(project): pre-commit issues were fixed

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,127 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2026-05-02T09:57:16Z"
+}

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -113,7 +113,7 @@ func Append(path, version string, date time.Time, commits []string) error {
 		out = section + existing
 	}
 
-	if err := os.WriteFile(path, []byte(out), 0o644); err != nil { //nolint:gosec
+	if err := os.WriteFile(path, []byte(out), 0o644); err != nil { // #nosec
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	return nil

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -10,11 +10,11 @@ import (
 
 // Entry represents a single release entry to append.
 type Entry struct {
-	Version string
-	Date    time.Time
-	Added   []string
-	Fixed   []string
-	Changed []string
+	Version  string
+	Date     time.Time
+	Added    []string
+	Fixed    []string
+	Changed  []string
 	Breaking []string
 }
 
@@ -36,7 +36,7 @@ func parseCommits(commits []string, e *Entry) {
 			e.Changed = append(e.Changed, msg)
 		case isType(msg, "refactor", false):
 			e.Changed = append(e.Changed, msg)
-		// chore, ci, docs, style, test, build → excluded from changelog
+			// chore, ci, docs, style, test, build → excluded from changelog
 		}
 	}
 }

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -93,7 +93,7 @@ func Append(path, version string, date time.Time, commits []string) error {
 	section := render(e)
 
 	var existing string
-	data, err := os.ReadFile(path) //nolint:gosec
+	data, err := os.ReadFile(path) // #nosec
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("reading %s: %w", path, err)
 	}

--- a/internal/chart/chart.go
+++ b/internal/chart/chart.go
@@ -61,7 +61,7 @@ func BumpVersion(path, newVersion string) error {
 		return fmt.Errorf("marshalling %s: %w", path, err)
 	}
 
-	if err := os.WriteFile(path, out, 0o644); err != nil { //nolint:gosec
+	if err := os.WriteFile(path, out, 0o644); err != nil { // #nosec
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 

--- a/internal/chart/chart.go
+++ b/internal/chart/chart.go
@@ -18,7 +18,7 @@ type Metadata struct {
 
 // Load reads a Chart.yaml file and returns its metadata.
 func Load(path string) (*Metadata, error) {
-	data, err := os.ReadFile(path) //nolint:gosec // path comes from controlled CLI input
+	data, err := os.ReadFile(path) // #nosec // path comes from controlled CLI input
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
@@ -41,7 +41,7 @@ func Load(path string) (*Metadata, error) {
 // BumpVersion rewrites only the `version:` line in a Chart.yaml file,
 // preserving all other content (comments, field order, appVersion, etc.).
 func BumpVersion(path, newVersion string) error {
-	data, err := os.ReadFile(path) //nolint:gosec
+	data, err := os.ReadFile(path) // #nosec
 	if err != nil {
 		return fmt.Errorf("reading %s: %w", path, err)
 	}

--- a/internal/registry/chartmuseum.go
+++ b/internal/registry/chartmuseum.go
@@ -42,7 +42,7 @@ func (p *ChartMuseumPublisher) Push(chartDir, _ string) error {
 		return fmt.Errorf("packaging chart %s: %w", ch.Name(), err)
 	}
 
-	f, err := os.Open(tgzPath) //nolint:gosec
+	f, err := os.Open(tgzPath) // #nosec
 	if err != nil {
 		return fmt.Errorf("opening packaged chart: %w", err)
 	}

--- a/internal/registry/ghpages.go
+++ b/internal/registry/ghpages.go
@@ -138,7 +138,7 @@ func MergeIndex(dst, src *helmrepo.IndexFile) {
 
 // copyFile copies src to dst.
 func copyFile(src, dst string) error {
-	data, err := os.ReadFile(src) //nolint:gosec
+	data, err := os.ReadFile(src) // #nosec
 	if err != nil {
 		return fmt.Errorf("reading %s: %w", src, err)
 	}

--- a/internal/registry/ghpages.go
+++ b/internal/registry/ghpages.go
@@ -142,7 +142,7 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("reading %s: %w", src, err)
 	}
-	if err := os.WriteFile(dst, data, 0o644); err != nil { //nolint:gosec
+	if err := os.WriteFile(dst, data, 0o644); err != nil { // #nosec
 		return fmt.Errorf("writing %s: %w", dst, err)
 	}
 	return nil

--- a/internal/registry/oci.go
+++ b/internal/registry/oci.go
@@ -56,7 +56,7 @@ func (p *OCIPublisher) Push(chartDir, version string) error {
 	}
 
 	// Read the packaged chart.
-	data, err := os.ReadFile(tgzPath) //nolint:gosec
+	data, err := os.ReadFile(tgzPath) // #nosec
 	if err != nil {
 		return fmt.Errorf("reading packaged chart: %w", err)
 	}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -43,7 +43,7 @@ func (c *Client) CreateRelease(ctx context.Context, tag, name, body string) (str
 
 // UploadAsset uploads a file as a release asset.
 func (c *Client) UploadAsset(ctx context.Context, releaseID int64, assetPath string) error {
-	f, err := os.Open(assetPath) //nolint:gosec
+	f, err := os.Open(assetPath) // #nosec
 	if err != nil {
 		return fmt.Errorf("opening asset %s: %w", assetPath, err)
 	}

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -15,7 +15,7 @@ type BumpType int
 
 const (
 	// BumpNone means no releasable commits were found.
-	BumpNone  BumpType = iota
+	BumpNone BumpType = iota
 	// BumpPatch is triggered by fix: commits.
 	BumpPatch
 	// BumpMinor is triggered by feat: commits.


### PR DESCRIPTION
## Summary

There were a number of files that caused lint errors with pre-commit. The primary culprit of was simply that `//nolint:gosec` was not getting recognized as a flag to ignore issues in specific lines. These issues were fixed by replacing that comment with `// #nosec`. 

Furthermore, the `Detect secrets` step in the pre-commit threw an error because `.secrets.baseline` doesn't exist in this project yet. This file was added from `ssmctl`. 

## What changed

`//nolint:gosec` was changed to `// #nosec` in the following files:

- `internal/registry/ghpages.go`
- `internal/registry/oci.go`
- `internal/registry/chartmuseum.go`
- `internal/chart/chart.go`
- `internal/changelog/changelog.go`
- `internal/release/release.go`

- `.secrets.baseline` was added to root directory.

