### PR TITLE
feat(changelog): improve changelog format with PR/commit links and release-please style

### DIFF
--- a/cmd/helm-semver/main.go
+++ b/cmd/helm-semver/main.go
@@ -186,7 +186,7 @@ func releaseChart(cmd *cobra.Command, opts *releaseOptions, gitClient *igit.Clie
 		return fmt.Errorf("listing commits for %s: %w", chartName, err)
 	}
 
-	bump := semver.Analyze(commits)
+	bump := semver.Analyze(igit.Subjects(commits))
 	if bump == semver.BumpNone {
 		_, _ = fmt.Fprintf(out, "  %s: no releasable commits — skipping\n", chartName)
 		return nil
@@ -227,7 +227,8 @@ func releaseChart(cmd *cobra.Command, opts *releaseOptions, gitClient *igit.Clie
 	// Update changelog.
 	if opts.changelog {
 		clPath := filepath.Join(chartDir, "CHANGELOG.md")
-		if err := changelog.Append(clPath, newVersion, time.Now(), commits); err != nil {
+		repo := changelog.RepoInfo{Owner: opts.githubOwner, Name: opts.githubRepo}
+		if err := changelog.Append(clPath, newVersion, time.Now(), commits, lastTag, newTag, repo); err != nil {
 			return fmt.Errorf("updating changelog: %w", err)
 		}
 		if err := gitClient.StageFile(filepath.Join(relPath, "CHANGELOG.md")); err != nil {
@@ -253,7 +254,7 @@ func releaseChart(cmd *cobra.Command, opts *releaseOptions, gitClient *igit.Clie
 
 	// GitHub Release.
 	if opts.githubRelease && opts.gitToken != "" {
-		notes := release.BuildReleaseNotes(commits)
+		notes := release.BuildReleaseNotes(commits, opts.githubOwner, opts.githubRepo)
 		rc := release.New(opts.gitToken, opts.githubOwner, opts.githubRepo)
 		url, err := rc.CreateRelease(context.Background(), newTag, chartName+" "+newVersion, notes)
 		if err != nil {

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -4,38 +4,90 @@ package changelog
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
+
+	igit "github.com/rhysmcneill/helm-semver/internal/git"
 )
+
+// RepoInfo holds GitHub repository coordinates for generating hyperlinks.
+type RepoInfo struct {
+	Owner string
+	Name  string
+}
 
 // Entry represents a single release entry to append.
 type Entry struct {
 	Version  string
 	Date     time.Time
-	Added    []string
-	Fixed    []string
-	Changed  []string
-	Breaking []string
+	PrevTag  string
+	NewTag   string
+	Repo     RepoInfo
+	Added    []igit.CommitInfo
+	Fixed    []igit.CommitInfo
+	Changed  []igit.CommitInfo
+	Breaking []igit.CommitInfo
+}
+
+var rePRSuffix = regexp.MustCompile(`\s*\(#\d+\)\s*$`)
+
+// stripPR removes a trailing "(#N)" PR reference from a commit subject so it
+// can be displayed separately as a hyperlink.
+func stripPR(subject string) string {
+	return strings.TrimSpace(rePRSuffix.ReplaceAllString(subject, ""))
+}
+
+// renderCommit formats a single commit as a list item with optional PR and
+// commit-SHA hyperlinks when repo coordinates are available.
+func renderCommit(c igit.CommitInfo, repo RepoInfo) string {
+	subject := c.Subject
+	if c.PR > 0 {
+		subject = stripPR(subject)
+	}
+
+	if repo.Owner == "" || repo.Name == "" {
+		return fmt.Sprintf("* %s", subject)
+	}
+
+	base := fmt.Sprintf("https://github.com/%s/%s", repo.Owner, repo.Name)
+	var links []string
+
+	if c.PR > 0 {
+		links = append(links, fmt.Sprintf("([#%d](%s/pull/%d))", c.PR, base, c.PR))
+	}
+	if c.Hash != "" {
+		short := c.Hash
+		if len(short) > 7 {
+			short = short[:7]
+		}
+		links = append(links, fmt.Sprintf("([%s](%s/commit/%s))", short, base, c.Hash))
+	}
+
+	if len(links) > 0 {
+		return fmt.Sprintf("* %s %s", subject, strings.Join(links, " "))
+	}
+	return fmt.Sprintf("* %s", subject)
 }
 
 // parseCommits categorises commit subjects into entry buckets.
 // Non-user-facing types (chore, ci, docs, style, test, build) are silently
 // excluded — they produce no changelog entry.
-func parseCommits(commits []string, e *Entry) {
-	for _, msg := range commits {
-		msg = strings.TrimSpace(msg)
+func parseCommits(commits []igit.CommitInfo, e *Entry) {
+	for _, info := range commits {
+		msg := strings.TrimSpace(info.Subject)
 		switch {
 		case strings.Contains(strings.ToUpper(msg), "BREAKING CHANGE") ||
 			isType(msg, "feat", true):
-			e.Breaking = append(e.Breaking, msg)
+			e.Breaking = append(e.Breaking, info)
 		case isType(msg, "feat", false):
-			e.Added = append(e.Added, msg)
+			e.Added = append(e.Added, info)
 		case isType(msg, "fix", false):
-			e.Fixed = append(e.Fixed, msg)
+			e.Fixed = append(e.Fixed, info)
 		case isType(msg, "perf", false):
-			e.Changed = append(e.Changed, msg)
+			e.Changed = append(e.Changed, info)
 		case isType(msg, "refactor", false):
-			e.Changed = append(e.Changed, msg)
+			e.Changed = append(e.Changed, info)
 			// chore, ci, docs, style, test, build → excluded from changelog
 		}
 	}
@@ -54,30 +106,38 @@ func isType(msg, t string, breaking bool) bool {
 // render formats an Entry into a markdown section string.
 func render(e *Entry) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## [%s] - %s\n", e.Version, e.Date.Format("2006-01-02"))
+
+	// Version heading with a compare link when repo info and tags are available.
+	if e.Repo.Owner != "" && e.Repo.Name != "" && e.PrevTag != "" && e.NewTag != "" {
+		compareURL := fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s",
+			e.Repo.Owner, e.Repo.Name, e.PrevTag, e.NewTag)
+		fmt.Fprintf(&sb, "## [%s](%s) (%s)\n", e.Version, compareURL, e.Date.Format("2006-01-02"))
+	} else {
+		fmt.Fprintf(&sb, "## [%s] - %s\n", e.Version, e.Date.Format("2006-01-02"))
+	}
 
 	if len(e.Breaking) > 0 {
-		sb.WriteString("\n### Breaking Changes\n")
+		sb.WriteString("\n### ⚠ BREAKING CHANGES\n")
 		for _, c := range e.Breaking {
-			fmt.Fprintf(&sb, "- %s\n", c)
+			fmt.Fprintf(&sb, "%s\n", renderCommit(c, e.Repo))
 		}
 	}
 	if len(e.Added) > 0 {
 		sb.WriteString("\n### Features\n")
 		for _, c := range e.Added {
-			fmt.Fprintf(&sb, "- %s\n", c)
+			fmt.Fprintf(&sb, "%s\n", renderCommit(c, e.Repo))
 		}
 	}
 	if len(e.Fixed) > 0 {
-		sb.WriteString("\n### Fixed\n")
+		sb.WriteString("\n### Bug Fixes\n")
 		for _, c := range e.Fixed {
-			fmt.Fprintf(&sb, "- %s\n", c)
+			fmt.Fprintf(&sb, "%s\n", renderCommit(c, e.Repo))
 		}
 	}
 	if len(e.Changed) > 0 {
 		sb.WriteString("\n### Changed\n")
 		for _, c := range e.Changed {
-			fmt.Fprintf(&sb, "- %s\n", c)
+			fmt.Fprintf(&sb, "%s\n", renderCommit(c, e.Repo))
 		}
 	}
 	sb.WriteString("\n")
@@ -85,9 +145,17 @@ func render(e *Entry) string {
 }
 
 // Append prepends a new release section to the CHANGELOG.md at path,
-// creating it if it does not exist.
-func Append(path, version string, date time.Time, commits []string) error {
-	e := &Entry{Version: version, Date: date}
+// creating it if it does not exist. prevTag and newTag are used to generate a
+// compare link in the release heading; repo provides the GitHub owner/name for
+// all hyperlinks. Pass empty strings / zero RepoInfo to omit links.
+func Append(path, version string, date time.Time, commits []igit.CommitInfo, prevTag, newTag string, repo RepoInfo) error {
+	e := &Entry{
+		Version: version,
+		Date:    date,
+		PrevTag: prevTag,
+		NewTag:  newTag,
+		Repo:    repo,
+	}
 	parseCommits(commits, e)
 
 	section := render(e)

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -6,23 +6,35 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	igit "github.com/rhysmcneill/helm-semver/internal/git"
 )
 
 var fixedDate = time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+
+// makeCommits builds a []igit.CommitInfo slice from bare subject strings with
+// stub hash values, for tests that don't need real SHAs.
+func makeCommits(subjects ...string) []igit.CommitInfo {
+	commits := make([]igit.CommitInfo, len(subjects))
+	for i, s := range subjects {
+		commits[i] = igit.CommitInfo{Subject: s, Hash: ""}
+	}
+	return commits
+}
 
 func TestAppend_NewFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "CHANGELOG.md")
 
-	commits := []string{
+	commits := makeCommits(
 		"feat: add OCI support",
 		"fix: correct tag prefix",
 		"chore: update deps",
 		"ci: add coverage check",
 		"docs: update readme",
-	}
+	)
 
-	if err := Append(path, "0.2.0", fixedDate, commits); err != nil {
+	if err := Append(path, "0.2.0", fixedDate, commits, "", "", RepoInfo{}); err != nil {
 		t.Fatalf("Append() error = %v", err)
 	}
 
@@ -35,8 +47,8 @@ func TestAppend_NewFile(t *testing.T) {
 	if !strings.Contains(content, "### Features") {
 		t.Errorf("missing Features section in:\n%s", content)
 	}
-	if !strings.Contains(content, "### Fixed") {
-		t.Errorf("missing Fixed section in:\n%s", content)
+	if !strings.Contains(content, "### Bug Fixes") {
+		t.Errorf("missing Bug Fixes section in:\n%s", content)
 	}
 	// chore/ci/docs must not appear in the changelog
 	if strings.Contains(content, "update deps") {
@@ -51,8 +63,8 @@ func TestAppend_Prepends(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "CHANGELOG.md")
 
-	_ = Append(path, "0.1.0", fixedDate, []string{"fix: initial release"})
-	_ = Append(path, "0.2.0", fixedDate.AddDate(0, 0, 1), []string{"feat: new flag"})
+	_ = Append(path, "0.1.0", fixedDate, makeCommits("fix: initial release"), "", "", RepoInfo{})
+	_ = Append(path, "0.2.0", fixedDate.AddDate(0, 0, 1), makeCommits("feat: new flag"), "", "", RepoInfo{})
 
 	data, _ := os.ReadFile(path) //nolint:gosec // path from t.TempDir()
 	content := string(data)
@@ -69,10 +81,10 @@ func TestAppend_PreservesExistingContent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "CHANGELOG.md")
 
-	existing := "# Changelog\n\n## [0.1.0] - 2026-01-01\n\n### Fixed\n- fix: old entry\n"
+	existing := "# Changelog\n\n## [0.1.0] - 2026-01-01\n\n### Bug Fixes\n- fix: old entry\n"
 	_ = os.WriteFile(path, []byte(existing), 0o600)
 
-	_ = Append(path, "0.2.0", fixedDate, []string{"feat: new feature"})
+	_ = Append(path, "0.2.0", fixedDate, makeCommits("feat: new feature"), "", "", RepoInfo{})
 
 	data, _ := os.ReadFile(path) //nolint:gosec // path from t.TempDir()
 	content := string(data)
@@ -82,5 +94,86 @@ func TestAppend_PreservesExistingContent(t *testing.T) {
 	}
 	if !strings.Contains(content, "0.2.0") {
 		t.Errorf("new version missing:\n%s", content)
+	}
+}
+
+func TestAppend_WithLinks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CHANGELOG.md")
+
+	commits := []igit.CommitInfo{
+		{Subject: "fix: auth error (#12)", Hash: "a1b2c3d4e5f6a7b8", PR: 12},   // pragma: allowlist secret
+		{Subject: "feat: new feature (#15)", Hash: "b2c3d4e5f6a7b8c9", PR: 15}, // pragma: allowlist secret
+	}
+
+	repo := RepoInfo{Owner: "owner", Name: "repo"}
+	if err := Append(path, "1.0.5", fixedDate, commits, "chart-v1.0.4", "chart-v1.0.5", repo); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	data, _ := os.ReadFile(path) //nolint:gosec // path from t.TempDir()
+	content := string(data)
+
+	// Release heading with compare link.
+	if !strings.Contains(content, "https://github.com/owner/repo/compare/chart-v1.0.4...chart-v1.0.5") {
+		t.Errorf("missing compare link in heading:\n%s", content)
+	}
+	// PR hyperlink.
+	if !strings.Contains(content, "[#12](https://github.com/owner/repo/pull/12)") {
+		t.Errorf("missing PR link:\n%s", content)
+	}
+	// Commit SHA hyperlink (7-char short SHA).
+	if !strings.Contains(content, "[a1b2c3d](https://github.com/owner/repo/commit/a1b2c3d4e5f6a7b8)") {
+		t.Errorf("missing commit SHA link:\n%s", content)
+	}
+	if !strings.Contains(content, "### Bug Fixes") {
+		t.Errorf("missing Bug Fixes section:\n%s", content)
+	}
+	if !strings.Contains(content, "### Features") {
+		t.Errorf("missing Features section:\n%s", content)
+	}
+}
+
+func TestAppend_BreakingChanges(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CHANGELOG.md")
+
+	commits := []igit.CommitInfo{
+		{Subject: "feat!: drop support for v1 (#20)", Hash: "deadbeef12345678", PR: 20}, // pragma: allowlist secret
+	}
+
+	if err := Append(path, "2.0.0", fixedDate, commits, "chart-v1.0.0", "chart-v2.0.0", RepoInfo{}); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	data, _ := os.ReadFile(path) //nolint:gosec // path from t.TempDir()
+	content := string(data)
+
+	if !strings.Contains(content, "### ⚠ BREAKING CHANGES") {
+		t.Errorf("missing breaking changes section heading:\n%s", content)
+	}
+}
+
+func TestAppend_NoLinksWhenRepoEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CHANGELOG.md")
+
+	commits := []igit.CommitInfo{
+		{Subject: "fix: something (#5)", Hash: "abc123def456", PR: 5}, // pragma: allowlist secret
+	}
+
+	if err := Append(path, "1.0.1", fixedDate, commits, "chart-v1.0.0", "chart-v1.0.1", RepoInfo{}); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	data, _ := os.ReadFile(path) //nolint:gosec // path from t.TempDir()
+	content := string(data)
+
+	if strings.Contains(content, "github.com") {
+		t.Errorf("links should not appear when RepoInfo is empty:\n%s", content)
+	}
+	// Plain version heading without compare URL.
+	if !strings.Contains(content, "## [1.0.1] - 2026-06-13") {
+		t.Errorf("missing plain version header:\n%s", content)
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,7 +4,9 @@ package git
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +17,36 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
+
+// CommitInfo holds data about a single commit.
+type CommitInfo struct {
+	Subject string // First line of the commit message.
+	Hash    string // Full 40-character SHA.
+	PR      int    // GitHub PR number parsed from trailing "(#N)", 0 if absent.
+}
+
+var rePR = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+
+// parsePR extracts a GitHub PR number from a commit subject line that ends with
+// "(#N)", as produced by GitHub's default merge commit message format. Returns 0
+// if no such suffix is present.
+func parsePR(subject string) int {
+	m := rePR.FindStringSubmatch(subject)
+	if m == nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n
+}
+
+// Subjects returns the Subject field of each CommitInfo, preserving order.
+func Subjects(commits []CommitInfo) []string {
+	out := make([]string, len(commits))
+	for i, c := range commits {
+		out[i] = c.Subject
+	}
+	return out
+}
 
 // Client wraps a go-git repository.
 type Client struct {
@@ -61,9 +93,10 @@ func (c *Client) LatestTag(chart string) (string, error) {
 	return matches[0], nil
 }
 
-// CommitsSince returns the commit subject lines for commits that touched
-// pathFilter since the given tag. If tag is empty, all commits are returned.
-func (c *Client) CommitsSince(tag, pathFilter string) ([]string, error) {
+// CommitsSince returns commits that touched pathFilter since the given tag.
+// If tag is empty, all commits are returned. Each CommitInfo carries the commit
+// subject, full SHA hash, and any GitHub PR number parsed from a "(#N)" trailer.
+func (c *Client) CommitsSince(tag, pathFilter string) ([]CommitInfo, error) {
 	var since *plumbing.Hash
 
 	if tag != "" {
@@ -93,22 +126,25 @@ func (c *Client) CommitsSince(tag, pathFilter string) ([]string, error) {
 		return nil, fmt.Errorf("git log: %w", err)
 	}
 
-	var subjects []string
+	var commits []CommitInfo
 	err = iter.ForEach(func(commit *object.Commit) error {
 		// Stop when we reach the tagged commit (exclusive).
 		if since != nil && commit.Hash == *since {
 			return storer.ErrStop
 		}
-		// Only the subject line (first line of message).
 		subject := strings.SplitN(strings.TrimSpace(commit.Message), "\n", 2)[0]
-		subjects = append(subjects, subject)
+		commits = append(commits, CommitInfo{
+			Subject: subject,
+			Hash:    commit.Hash.String(),
+			PR:      parsePR(subject),
+		})
 		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("iterating commits: %w", err)
 	}
 
-	return subjects, nil
+	return commits, nil
 }
 
 // StageFile adds a file to the git index.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -98,6 +98,52 @@ func TestCommitsSince_NoTag(t *testing.T) {
 	if len(commits) < 2 {
 		t.Errorf("CommitsSince() returned %d commits, want >= 2", len(commits))
 	}
+	for _, ci := range commits {
+		if ci.Subject == "" {
+			t.Error("CommitInfo.Subject should not be empty")
+		}
+		if ci.Hash == "" {
+			t.Error("CommitInfo.Hash should not be empty")
+		}
+		if len(ci.Hash) != 40 {
+			t.Errorf("CommitInfo.Hash should be 40 chars, got %d: %s", len(ci.Hash), ci.Hash)
+		}
+	}
+}
+
+func TestParsePR(t *testing.T) {
+	tests := []struct {
+		subject string
+		want    int
+	}{
+		{"feat: add redis (#42)", 42},
+		{"fix: auth error (#123)", 123},
+		{"chore: cleanup", 0},
+		{"feat: no trailing paren (#", 0},
+	}
+	for _, tt := range tests {
+		got := parsePR(tt.subject)
+		if got != tt.want {
+			t.Errorf("parsePR(%q) = %d, want %d", tt.subject, got, tt.want)
+		}
+	}
+}
+
+func TestSubjects(t *testing.T) {
+	commits := []CommitInfo{
+		{Subject: "feat: a", Hash: "abc123", PR: 1},
+		{Subject: "fix: b", Hash: "def456", PR: 0},
+	}
+	got := Subjects(commits)
+	want := []string{"feat: a", "fix: b"}
+	if len(got) != len(want) {
+		t.Fatalf("Subjects() len = %d, want %d", len(got), len(want))
+	}
+	for i, s := range got {
+		if s != want[i] {
+			t.Errorf("Subjects()[%d] = %q, want %q", i, s, want[i])
+		}
+	}
 }
 
 func TestStageAndCommit(t *testing.T) {

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/google/go-github/v63/github"
 	"golang.org/x/oauth2"
+
+	igit "github.com/rhysmcneill/helm-semver/internal/git"
 )
 
 // Client wraps the GitHub API for creating releases.
@@ -58,14 +61,39 @@ func (c *Client) UploadAsset(ctx context.Context, releaseID int64, assetPath str
 	return nil
 }
 
-// BuildReleaseNotes formats commit subjects into a markdown release notes body.
-func BuildReleaseNotes(commits []string) string {
+// BuildReleaseNotes formats commits into a markdown release notes body.
+// When repoOwner and repoName are non-empty, each entry includes PR and commit
+// SHA hyperlinks matching the release-please format.
+func BuildReleaseNotes(commits []igit.CommitInfo, repoOwner, repoName string) string {
 	if len(commits) == 0 {
 		return ""
 	}
-	var out string
-	for _, c := range commits {
-		out += "- " + c + "\n"
+
+	repoBase := ""
+	if repoOwner != "" && repoName != "" {
+		repoBase = fmt.Sprintf("https://github.com/%s/%s", repoOwner, repoName)
 	}
-	return out
+
+	var sb strings.Builder
+	for _, c := range commits {
+		var links []string
+		if repoBase != "" {
+			if c.PR > 0 {
+				links = append(links, fmt.Sprintf("([#%d](%s/pull/%d))", c.PR, repoBase, c.PR))
+			}
+			if c.Hash != "" {
+				short := c.Hash
+				if len(short) > 7 {
+					short = short[:7]
+				}
+				links = append(links, fmt.Sprintf("([%s](%s/commit/%s))", short, repoBase, c.Hash))
+			}
+		}
+		if len(links) > 0 {
+			fmt.Fprintf(&sb, "- %s %s\n", c.Subject, strings.Join(links, " "))
+		} else {
+			fmt.Fprintf(&sb, "- %s\n", c.Subject)
+		}
+	}
+	return sb.String()
 }

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -3,20 +3,22 @@ package release
 import (
 	"strings"
 	"testing"
+
+	igit "github.com/rhysmcneill/helm-semver/internal/git"
 )
 
 func TestBuildReleaseNotes(t *testing.T) {
-	commits := []string{
-		"feat: add OCI support",
-		"fix: correct tag prefix",
-		"chore: update deps",
+	commits := []igit.CommitInfo{
+		{Subject: "feat: add OCI support", Hash: "a1b2c3d4e5f67890", PR: 0},   // pragma: allowlist secret
+		{Subject: "fix: correct tag prefix", Hash: "b2c3d4e5f6789012", PR: 0}, // pragma: allowlist secret
+		{Subject: "chore: update deps", Hash: "c3d4e5f678901234", PR: 0},      // pragma: allowlist secret
 	}
 
-	notes := BuildReleaseNotes(commits)
+	notes := BuildReleaseNotes(commits, "", "")
 
 	for _, c := range commits {
-		if !strings.Contains(notes, c) {
-			t.Errorf("release notes missing commit %q:\n%s", c, notes)
+		if !strings.Contains(notes, c.Subject) {
+			t.Errorf("release notes missing commit %q:\n%s", c.Subject, notes)
 		}
 	}
 	if !strings.HasPrefix(notes, "- ") {
@@ -24,8 +26,23 @@ func TestBuildReleaseNotes(t *testing.T) {
 	}
 }
 
+func TestBuildReleaseNotes_WithLinks(t *testing.T) {
+	commits := []igit.CommitInfo{
+		{Subject: "fix: auth error (#12)", Hash: "a1b2c3d4e5f6a7b8", PR: 12}, // pragma: allowlist secret
+	}
+
+	notes := BuildReleaseNotes(commits, "owner", "repo")
+
+	if !strings.Contains(notes, "[#12](https://github.com/owner/repo/pull/12)") {
+		t.Errorf("missing PR link in release notes:\n%s", notes)
+	}
+	if !strings.Contains(notes, "[a1b2c3d](https://github.com/owner/repo/commit/a1b2c3d4e5f6a7b8)") {
+		t.Errorf("missing commit SHA link in release notes:\n%s", notes)
+	}
+}
+
 func TestBuildReleaseNotes_Empty(t *testing.T) {
-	notes := BuildReleaseNotes(nil)
+	notes := BuildReleaseNotes(nil, "", "")
 	if notes != "" {
 		t.Errorf("expected empty string for nil commits, got %q", notes)
 	}


### PR DESCRIPTION
## Summary

Closes #22

Aligns the changelog (and GitHub Release notes) format with `release-please` conventions.

### Changes

- **`internal/git`** — added `CommitInfo{Subject, Hash, PR}` struct; `CommitsSince` now returns `[]CommitInfo` (full SHA + PR number parsed from `(#N)` trailer) instead of `[]string`; added `Subjects()` and `parsePR()` helpers
- **`internal/changelog`** — `### Fixed` → `### Bug Fixes`; `### Breaking Changes` → `### ⚠ BREAKING CHANGES`; release heading now includes a compare link (`## [1.0.5](…/compare/chart-v1.0.4…chart-v1.0.5) (2026-06-17)`); each entry rendered as `* subject ([#N](…/pull/N)) ([a1b2c3d](…/commit/…))`; links omitted gracefully when repo info is absent
- **`internal/release`** — `BuildReleaseNotes` updated to accept `[]git.CommitInfo` + repo coordinates and renders the same PR/SHA links in GitHub Release bodies
- **`cmd/helm-semver/main`** — threads `lastTag`, `newTag`, and `RepoInfo{githubOwner, githubRepo}` through to `changelog.Append`; passes owner/repo to `BuildReleaseNotes`

## Test plan

- [x] `TestAppend_NewFile` — `### Features` and `### Bug Fixes` headings present; chore/ci/docs excluded
- [x] `TestAppend_Prepends` — newer release appears above older one
- [x] `TestAppend_PreservesExistingContent` — existing content not lost on append
- [x] `TestAppend_WithLinks` — compare URL in heading, PR link, 7-char SHA link
- [x] `TestAppend_BreakingChanges` — `### ⚠ BREAKING CHANGES` rendered for `feat!:` commits
- [x] `TestAppend_NoLinksWhenRepoEmpty` — no `github.com` links when `RepoInfo` is zero-value
- [x] `TestBuildReleaseNotes_WithLinks` — PR and SHA links in release notes
- [x] All existing tests continue to pass (`go test ./...`)