### PR TITLE
feat: build chart dependencies before packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Flags:
   --dry-run                     Print what would happen without making any changes
   --changelog                   Append release entry to CHANGELOG.md per chart (default true)
   --github-release              Create a GitHub Release for each chart
+  --dependency-build            Build chart dependencies (helm dependency build) before packaging (default true)
   --github-token string         GitHub token (env: GITHUB_TOKEN)
   --github-owner string         GitHub repository owner (env: GITHUB_REPOSITORY_OWNER)
   --github-repo string          GitHub repository name

--- a/cmd/helm-semver/main.go
+++ b/cmd/helm-semver/main.go
@@ -53,21 +53,22 @@ func newVersionCmd() *cobra.Command {
 }
 
 type releaseOptions struct {
-	chartsDir     string
-	registry      string
-	registryType  string
-	registryUser  string
-	registryPass  string
-	gitPush       bool
-	dryRun        bool
-	changelog     bool
-	githubRelease bool
-	gitToken      string
-	githubOwner   string
-	githubRepo    string
-	tagPrefix     string
-	authorName    string
-	authorEmail   string
+	chartsDir       string
+	registry        string
+	registryType    string
+	registryUser    string
+	registryPass    string
+	gitPush         bool
+	dryRun          bool
+	changelog       bool
+	githubRelease   bool
+	dependencyBuild bool
+	gitToken        string
+	githubOwner     string
+	githubRepo      string
+	tagPrefix       string
+	authorName      string
+	authorEmail     string
 }
 
 func newReleaseCmd() *cobra.Command {
@@ -93,6 +94,7 @@ and pushes it to the configured registry.`,
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Print what would happen without making any changes")
 	cmd.Flags().BoolVar(&opts.changelog, "changelog", true, "Append release entry to CHANGELOG.md per chart")
 	cmd.Flags().BoolVar(&opts.githubRelease, "github-release", false, "Create a GitHub Release for each chart")
+	cmd.Flags().BoolVar(&opts.dependencyBuild, "dependency-build", true, "Build chart dependencies (helm dependency build) before packaging")
 	cmd.Flags().StringVar(&opts.gitToken, "git-token", os.Getenv("GITHUB_TOKEN"), "Token for git push authentication (env: GITHUB_TOKEN)")
 	// --github-token is a deprecated alias kept for backwards compatibility.
 	cmd.Flags().StringVar(&opts.gitToken, "github-token", os.Getenv("GITHUB_TOKEN"), "Deprecated: use --git-token")
@@ -216,6 +218,14 @@ func releaseChart(cmd *cobra.Command, opts *releaseOptions, gitClient *igit.Clie
 	// Bump Chart.yaml.
 	if err := chart.BumpVersion(filepath.Join(chartDir, "Chart.yaml"), newVersion); err != nil {
 		return fmt.Errorf("bumping version for %s: %w", chartName, err)
+	}
+
+	// Vendor declared dependencies before packaging so the published chart
+	// is self-contained.
+	if opts.dependencyBuild {
+		if err := chart.BuildDependencies(chartDir, out); err != nil {
+			return fmt.Errorf("building dependencies for %s: %w", chartName, err)
+		}
 	}
 
 	// Push to registry.

--- a/internal/chart/dependencies.go
+++ b/internal/chart/dependencies.go
@@ -1,0 +1,68 @@
+package chart
+
+import (
+	"fmt"
+	"io"
+
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/downloader"
+	"helm.sh/helm/v3/pkg/getter"
+	helmregistry "helm.sh/helm/v3/pkg/registry"
+)
+
+// HasDependencies reports whether the chart at chartDir declares any
+// dependencies in its Chart.yaml.
+func HasDependencies(chartDir string) (bool, error) {
+	ch, err := loader.Load(chartDir)
+	if err != nil {
+		return false, fmt.Errorf("loading chart at %s: %w", chartDir, err)
+	}
+	return len(ch.Metadata.Dependencies) > 0, nil
+}
+
+// BuildDependencies vendors the dependencies declared in Chart.yaml into the
+// chart's charts/ directory before packaging, equivalent to running
+// `helm dependency build`.
+//
+// Like the Helm CLI, it respects a committed Chart.lock: dependencies are
+// fetched exactly as locked and a lock that is out of sync with Chart.yaml
+// fails loudly instead of silently drifting. Charts that declare no
+// dependencies are left untouched.
+func BuildDependencies(chartDir string, out io.Writer) error {
+	has, err := HasDependencies(chartDir)
+	if err != nil {
+		return err
+	}
+	if !has {
+		return nil
+	}
+
+	if out == nil {
+		out = io.Discard
+	}
+
+	settings := cli.New()
+	regClient, err := helmregistry.NewClient(
+		helmregistry.ClientOptDebug(settings.Debug),
+		helmregistry.ClientOptCredentialsFile(settings.RegistryConfig),
+	)
+	if err != nil {
+		return fmt.Errorf("creating registry client: %w", err)
+	}
+
+	man := &downloader.Manager{
+		Out:              out,
+		ChartPath:        chartDir,
+		SkipUpdate:       true,
+		Getters:          getter.All(settings),
+		RegistryClient:   regClient,
+		RepositoryConfig: settings.RepositoryConfig,
+		RepositoryCache:  settings.RepositoryCache,
+		Debug:            settings.Debug,
+	}
+	if err := man.Build(); err != nil {
+		return fmt.Errorf("building dependencies for chart at %s: %w", chartDir, err)
+	}
+	return nil
+}

--- a/internal/chart/dependencies_test.go
+++ b/internal/chart/dependencies_test.go
@@ -1,0 +1,195 @@
+package chart
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/downloader"
+	"helm.sh/helm/v3/pkg/getter"
+)
+
+// writeDepWorkspace creates a parent chart with a file:// dependency on a
+// local subchart, so dependency resolution stays fully offline.
+//
+//	root/
+//	├── parent/Chart.yaml  (depends on sub via file://../sub)
+//	└── sub/Chart.yaml
+func writeDepWorkspace(t *testing.T) (parentDir string) {
+	t.Helper()
+	root := t.TempDir()
+
+	subDir := filepath.Join(root, "sub")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("creating subchart dir: %v", err)
+	}
+	subChart := `apiVersion: v2
+name: sub
+version: 0.1.0
+`
+	if err := os.WriteFile(filepath.Join(subDir, "Chart.yaml"), []byte(subChart), 0o600); err != nil {
+		t.Fatalf("writing subchart: %v", err)
+	}
+
+	parentDir = filepath.Join(root, "parent")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatalf("creating parent dir: %v", err)
+	}
+	parentChart := `apiVersion: v2
+name: parent
+version: 0.1.0
+dependencies:
+  - name: sub
+    version: "0.1.0"
+    repository: "file://../sub"
+`
+	if err := os.WriteFile(filepath.Join(parentDir, "Chart.yaml"), []byte(parentChart), 0o600); err != nil {
+		t.Fatalf("writing parent chart: %v", err)
+	}
+
+	return parentDir
+}
+
+// generateLock runs the equivalent of `helm dependency update` offline
+// (file:// dependency) to produce a committed Chart.lock, then removes the
+// vendored charts/ directory so BuildDependencies has work to do.
+func generateLock(t *testing.T, chartDir string) {
+	t.Helper()
+	settings := cli.New()
+	man := &downloader.Manager{
+		Out:              io.Discard,
+		ChartPath:        chartDir,
+		SkipUpdate:       true,
+		Getters:          getter.All(settings),
+		RepositoryConfig: settings.RepositoryConfig,
+		RepositoryCache:  settings.RepositoryCache,
+	}
+	if err := man.Update(); err != nil {
+		t.Fatalf("generating Chart.lock: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(chartDir, "Chart.lock")); err != nil {
+		t.Fatalf("Chart.lock was not created: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(chartDir, "charts")); err != nil {
+		t.Fatalf("removing vendored charts dir: %v", err)
+	}
+}
+
+func packageChart(chartDir string) error {
+	pkg := action.NewPackage()
+	dest, err := os.MkdirTemp("", "helm-semver-test-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dest) //nolint:errcheck
+	pkg.Destination = dest
+	_, err = pkg.Run(chartDir, nil)
+	return err
+}
+
+func TestBuildDependencies_VendorsSubchartsBeforePackaging(t *testing.T) {
+	parentDir := writeDepWorkspace(t)
+	generateLock(t, parentDir)
+
+	// Defect evidence: packaging a chart whose declared dependencies are not
+	// vendored in charts/ fails.
+	if err := packageChart(parentDir); err == nil {
+		t.Fatal("expected packaging to fail with missing dependencies, got nil")
+	} else if !strings.Contains(err.Error(), "missing in charts") {
+		t.Fatalf("unexpected packaging error: %v", err)
+	}
+
+	// The fix: BuildDependencies vendors the subchart before packaging.
+	if err := BuildDependencies(parentDir, io.Discard); err != nil {
+		t.Fatalf("BuildDependencies() error = %v", err)
+	}
+
+	vendored := filepath.Join(parentDir, "charts", "sub-0.1.0.tgz")
+	if _, err := os.Stat(vendored); err != nil {
+		t.Fatalf("expected vendored subchart at %s: %v", vendored, err)
+	}
+
+	if err := packageChart(parentDir); err != nil {
+		t.Fatalf("packaging after dependency build failed: %v", err)
+	}
+}
+
+func TestBuildDependencies_NoDependencies(t *testing.T) {
+	dir := t.TempDir()
+	content := `apiVersion: v2
+name: standalone
+version: 0.1.0
+`
+	if err := os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("writing chart: %v", err)
+	}
+
+	if err := BuildDependencies(dir, io.Discard); err != nil {
+		t.Fatalf("BuildDependencies() error = %v", err)
+	}
+
+	// A chart without dependencies must be left untouched.
+	if _, err := os.Stat(filepath.Join(dir, "charts")); !os.IsNotExist(err) {
+		t.Errorf("charts/ directory should not exist for a dependency-less chart")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "Chart.lock")); !os.IsNotExist(err) {
+		t.Errorf("Chart.lock should not be created for a dependency-less chart")
+	}
+}
+
+func TestBuildDependencies_LockDriftFails(t *testing.T) {
+	parentDir := writeDepWorkspace(t)
+	generateLock(t, parentDir)
+
+	// Drift the dependency constraint away from the committed lock.
+	drifted := `apiVersion: v2
+name: parent
+version: 0.1.0
+dependencies:
+  - name: sub
+    version: "0.2.0"
+    repository: "file://../sub"
+`
+	if err := os.WriteFile(filepath.Join(parentDir, "Chart.yaml"), []byte(drifted), 0o600); err != nil {
+		t.Fatalf("writing drifted chart: %v", err)
+	}
+
+	err := BuildDependencies(parentDir, io.Discard)
+	if err == nil {
+		t.Fatal("expected lock drift to fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "out of sync") {
+		t.Fatalf("expected lock drift error, got: %v", err)
+	}
+}
+
+func TestHasDependencies(t *testing.T) {
+	withDeps := writeDepWorkspace(t)
+	has, err := HasDependencies(withDeps)
+	if err != nil {
+		t.Fatalf("HasDependencies() error = %v", err)
+	}
+	if !has {
+		t.Error("HasDependencies() = false, want true")
+	}
+
+	dir := t.TempDir()
+	content := `apiVersion: v2
+name: standalone
+version: 0.1.0
+`
+	if err := os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("writing chart: %v", err)
+	}
+	has, err = HasDependencies(dir)
+	if err != nil {
+		t.Fatalf("HasDependencies() error = %v", err)
+	}
+	if has {
+		t.Error("HasDependencies() = true, want false")
+	}
+}


### PR DESCRIPTION
## Problem

`helm-semver release` never builds chart dependencies. Every registry publisher (`internal/registry/oci.go`, `chartmuseum.go`, `ghpages.go`) calls `action.NewPackage().Run(chartDir, nil)` on the chart directory as-is. When a chart declares `dependencies:` in `Chart.yaml` and the subcharts are not already vendored in `charts/`, this means either:

- packaging fails outright with `found in Chart.yaml, but missing in charts/ directory`, or
- the published OCI/ChartMuseum/GitHub Pages artifact silently omits the declared subcharts.

Any chart that legitimately declares dependencies (e.g. an umbrella chart, or a chart layering on `common` library charts) cannot be released through this tool.

## Fix

Run the equivalent of `helm dependency build` once in the release flow, before `Publisher.Push`, so all three publishers are covered with no per-publisher duplication:

- New `internal/chart/dependencies.go`:
  - `BuildDependencies(chartDir, out)` uses the Helm v3 SDK `downloader.Manager{SkipUpdate: true, ...}.Build()` — the same code path as `helm dependency build`. `Build` (not `Update`) is used deliberately: a committed `Chart.lock` is respected exactly, and a lock that is out of sync with `Chart.yaml` fails loudly instead of silently drifting.
  - Charts that declare no dependencies are detected up front (`HasDependencies`) and left completely untouched — no `charts/` directory, no `Chart.lock`, no network access.
- The call is wired into `releaseChart` in `cmd/helm-semver/main.go`, after the version bump and before `pub.Push`.
- New CLI flag `--dependency-build` (default `true`) threads through `releaseOptions`, so consumers can opt out when they vendor dependencies themselves.

## Tests

New offline tests in `internal/chart/dependencies_test.go` (local `file://` subchart fixture, no network):

```
=== RUN   TestBuildDependencies_VendorsSubchartsBeforePackaging
--- PASS: TestBuildDependencies_VendorsSubchartsBeforePackaging (15.57s)
=== RUN   TestBuildDependencies_NoDependencies
--- PASS: TestBuildDependencies_NoDependencies (0.00s)
=== RUN   TestBuildDependencies_LockDriftFails
--- PASS: TestBuildDependencies_LockDriftFails (8.23s)
=== RUN   TestHasDependencies
--- PASS: TestHasDependencies (0.00s)
PASS
ok  	github.com/rhysmcneill/helm-semver/internal/chart	23.862s
```

`TestBuildDependencies_VendorsSubchartsBeforePackaging` also proves the defect: before the dependency build, `Package.Run` fails with `missing in charts`; after it, packaging succeeds with the subchart vendored.

Full suite, build, and vet are green:

```
go build ./...   # exit 0
go vet ./...     # exit 0
go test ./...    # ok for all packages
```

## Notes

- Like `helm dependency build` itself, remote (non-`file://`, non-OCI) repository dependencies require the repository to be configured (`helm repo add`) since `SkipUpdate` is set — index caches are not refreshed implicitly. OCI dependencies work through the standard Helm registry credentials file.
